### PR TITLE
IE7 Fix

### DIFF
--- a/jquery.ajax-session-storage-cache.js
+++ b/jquery.ajax-session-storage-cache.js
@@ -91,7 +91,9 @@
   }
   
   $.AjaxSessionStorageCache.prototype.setSessionStorageCache = function(value) {
-    sessionStorage.setItem(this.key, value);
+    if (this.supportsSessionStorage()) {
+      sessionStorage.setItem(this.key, value);
+    }
   }
   
   $.ajax_session_storage_cache = function(options) {


### PR DESCRIPTION
IE7 was throwing an error about an sessionStorage not being defined.  (Sorry, I didn't write down the actual wording of the error.)  This commit adds a test to make sure that sessionStorage is supported before trying to set a value in the store.
